### PR TITLE
Improve subscription disposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,9 @@ if (streamPage.isEnd === false) {
 We can also read all messages from all streams back in the order they were saved.
 
 ```ts
-import { Position } from 'snicket'
+import { ReadFrom } from 'snicket'
 let allPage = await store.readStream(
-  Position.Start,  // From what global position?
+  ReadFrom.Start,  // From what global position?
   100 // How many to read?
 )
 
@@ -284,7 +284,7 @@ Both reads support reading backwards, too.
 import { ReadDirection } from 'snicket'
 
 await store.readStream(
-  Position.Start, 
+  ReadFrom.Start, 
   100,
   ReadDirection.Backward // The default is `Forward`.
 )

--- a/src/__acceptance__/stream-store.dispose.test.ts
+++ b/src/__acceptance__/stream-store.dispose.test.ts
@@ -1,48 +1,125 @@
 import { StreamStore, ExpectedVersion, DisposedError } from '..'
 import { v4 } from 'uuid'
 import { noop } from 'lodash'
+import { delay } from '../utils/promise-util'
+import { createResetEvent } from '../utils/reset-event'
+
+// tslint:disable:no-floating-promises
 
 export function disposeTestsFor(
   getStore: () => Promise<StreamStore>,
   teardown?: () => Promise<unknown>
 ) {
-  let store: StreamStore
-  beforeAll(async () => {
-    store = await getStore()
-  })
-  afterAll(() =>
-    store
-      .dispose()
-      .catch(Boolean)
-      .then(teardown)
-  )
+  /* istanbul ignore next */
+  afterAll(() => teardown && teardown())
 
   test('waits for writes', async () => {
-    const streamId = v4()
-    // Make sure there's a subscription to dispose as well.
-    await store.subscribeToStream(streamId, noop as any)
-    const p = store.appendToStream(streamId, ExpectedVersion.Empty, [
-      {
-        messageId: v4(),
-        data: {},
-        type: 'test'
-      }
-    ])
-
-    await store.dispose()
-    const appendResult = await p
-    expect(appendResult.streamVersion).toBe(0)
-
-    await expect(
-      store.appendToStream(streamId, ExpectedVersion.Empty, [
+    const store = await getStore()
+    try {
+      const streamId = v4()
+      // Make sure there's a subscription to dispose as well.
+      await store.subscribeToStream(streamId, noop as any)
+      const p = store.appendToStream(streamId, ExpectedVersion.Empty, [
         {
           messageId: v4(),
           data: {},
           type: 'test'
         }
       ])
-    ).rejects.toBeInstanceOf(DisposedError)
 
-    await expect(store.dispose()).rejects.toBeInstanceOf(DisposedError)
+      await store.dispose()
+      const appendResult = await p
+      expect(appendResult.streamVersion).toBe(0)
+
+      await expect(
+        store.appendToStream(streamId, ExpectedVersion.Empty, [
+          {
+            messageId: v4(),
+            data: {},
+            type: 'test'
+          }
+        ])
+      ).rejects.toBeInstanceOf(DisposedError)
+
+      await expect(store.dispose()).rejects.toBeInstanceOf(DisposedError)
+    } finally {
+      await store.dispose().catch(Boolean)
+    }
+  })
+
+  test('waits for subscriptions', async () => {
+    const store = await getStore()
+    try {
+      const streamId = v4()
+
+      // Used to track whether, when the test ends, that the subscription handlers
+      // were allowed to run to completion and that the store.dispose accounted for it.
+      let streamSubCompleted = 0
+      let streamSubDisposerCompleted = 0
+      let allSubCompleted = 0
+      let allSubDisposerCompleted = 0
+
+      // Signals to the test code that the message handler has started.
+      const onStreamMessage = createResetEvent()
+      const onAllMessage = createResetEvent()
+      const streamSub = await store.subscribeToStream(
+        streamId,
+        () => {
+          onStreamMessage.set()
+          return delay(500).then(() => {
+            streamSubCompleted++
+          })
+        },
+        {
+          dispose: () =>
+            delay(500).then(() => {
+              streamSubDisposerCompleted++
+            })
+        }
+      )
+      const allSub = await store.subscribeToAll(
+        async msg => {
+          // Only "listen" for the stream message.
+          /* istanbul ignore else */
+          if (msg.streamId === streamId) {
+            onAllMessage.set()
+            return delay(500).then(() => {
+              allSubCompleted++
+            })
+          }
+        },
+        {
+          dispose: () =>
+            delay(500).then(() => {
+              allSubDisposerCompleted++
+            })
+        }
+      )
+      const onStreamMessagePromise = onStreamMessage.wait()
+      const onAllMessagePromise = onAllMessage.wait()
+      await store.appendToStream(streamId, ExpectedVersion.Empty, [
+        {
+          messageId: v4(),
+          data: {},
+          type: 'test'
+        }
+      ])
+
+      await onStreamMessagePromise
+      streamSub.dispose()
+      streamSub.dispose() // idempotent
+
+      await onAllMessagePromise
+      allSub.dispose()
+      allSub.dispose() // idempotent
+
+      await store.dispose()
+      expect(streamSubCompleted).toBe(1)
+      expect(allSubCompleted).toBe(1)
+      expect(streamSubDisposerCompleted).toBe(1)
+      expect(allSubDisposerCompleted).toBe(1)
+    } finally {
+      await store.dispose().catch(Boolean)
+    }
   })
 }

--- a/src/__acceptance__/stream-store.idempotency.test.ts
+++ b/src/__acceptance__/stream-store.idempotency.test.ts
@@ -3,7 +3,7 @@ import { StreamStore, ExpectedVersion } from '..'
 import { v4 } from 'uuid'
 import { generateMessages } from '../__helpers__/message-helper'
 import { WrongExpectedVersionError } from '../errors/errors'
-import { Position } from '../types/messages'
+import { ReadFrom } from '../types/messages'
 
 export function idempotencyTestsFor(
   getStore: () => Promise<StreamStore>,
@@ -73,7 +73,7 @@ export function idempotencyTestsFor(
 
       expect(
         await store
-          .readStream(streamId, Position.Start, 100)
+          .readStream(streamId, ReadFrom.Start, 100)
           .then(x => x.messages.length)
       ).toBe(5)
     })
@@ -95,7 +95,7 @@ export function idempotencyTestsFor(
 
       expect(
         await store
-          .readStream(streamId, Position.Start, 10)
+          .readStream(streamId, ReadFrom.Start, 10)
           .then(x => x.messages.length)
       ).toBe(3)
 
@@ -108,7 +108,7 @@ export function idempotencyTestsFor(
 
       expect(
         await store
-          .readStream(streamId, Position.Start, 10)
+          .readStream(streamId, ReadFrom.Start, 10)
           .then(x => x.messages.length)
       ).toBe(3)
     })
@@ -237,7 +237,7 @@ export function idempotencyTestsFor(
 
       expect(
         await store
-          .readStream(streamId, Position.Start, 10)
+          .readStream(streamId, ReadFrom.Start, 10)
           .then(x => x.messages.length)
       ).toBe(3)
 
@@ -251,7 +251,7 @@ export function idempotencyTestsFor(
 
       expect(
         await store
-          .readStream(streamId, Position.Start, 10)
+          .readStream(streamId, ReadFrom.Start, 10)
           .then(x => x.messages.length)
       ).toBe(3)
     })

--- a/src/__acceptance__/stream-store.readAll.test.ts
+++ b/src/__acceptance__/stream-store.readAll.test.ts
@@ -1,4 +1,4 @@
-import { StreamStore, ExpectedVersion, Position, ReadDirection } from '..'
+import { StreamStore, ExpectedVersion, ReadFrom, ReadDirection } from '..'
 import { v4 } from 'uuid'
 import { generateMessages } from '../__helpers__/message-helper'
 
@@ -17,7 +17,7 @@ export function readAllTestsFor(
 
   test('empty', async () => {
     expect(
-      await store.readAll(Position.Start, 10, ReadDirection.Forward)
+      await store.readAll(ReadFrom.Start, 10, ReadDirection.Forward)
     ).toEqual({
       isEnd: true,
       messages: [],
@@ -25,7 +25,7 @@ export function readAllTestsFor(
     })
 
     expect(
-      await store.readAll(Position.Start, 10, ReadDirection.Backward)
+      await store.readAll(ReadFrom.Start, 10, ReadDirection.Backward)
     ).toEqual({
       isEnd: true,
       messages: [],
@@ -36,7 +36,7 @@ export function readAllTestsFor(
     await store.appendToStream(v4(), ExpectedVersion.Empty, [])
 
     expect(
-      await store.readAll(Position.Start, 10, ReadDirection.Forward)
+      await store.readAll(ReadFrom.Start, 10, ReadDirection.Forward)
     ).toEqual({
       isEnd: true,
       messages: [],
@@ -44,9 +44,9 @@ export function readAllTestsFor(
     })
 
     expect(
-      // Note, using Position.End here is intentional, the end
+      // Note, using ReadFrom.End here is intentional, the end
       // result should be the same but different code paths might be triggered.
-      await store.readAll(Position.End, 10, ReadDirection.Backward)
+      await store.readAll(ReadFrom.End, 10, ReadDirection.Backward)
     ).toEqual({
       isEnd: true,
       messages: [],
@@ -98,7 +98,7 @@ export function readAllTestsFor(
 
     test('can read backwards', async () => {
       const result1 = await store.readAll(
-        Position.End,
+        ReadFrom.End,
         10,
         ReadDirection.Backward
       )
@@ -116,7 +116,7 @@ export function readAllTestsFor(
       expect(result2.messages.length).toBe(10)
 
       const allResult = await store.readAll(
-        Position.End,
+        ReadFrom.End,
         1000,
         ReadDirection.Backward
       )

--- a/src/__acceptance__/stream-store.readStream.test.ts
+++ b/src/__acceptance__/stream-store.readStream.test.ts
@@ -1,5 +1,5 @@
 import { v4 } from 'uuid'
-import { StreamStore, ExpectedVersion, Position, ReadDirection } from '..'
+import { StreamStore, ExpectedVersion, ReadFrom, ReadDirection } from '..'
 import { generateMessages } from '../__helpers__/message-helper'
 
 jest.setTimeout(6000000)
@@ -156,7 +156,7 @@ export function readStreamTestsFor(
       )
       const result1 = await store.readStream(
         streamId,
-        Position.End,
+        ReadFrom.End,
         5,
         ReadDirection.Backward
       )
@@ -184,7 +184,7 @@ export function readStreamTestsFor(
 
       const allResult = await store.readStream(
         streamId,
-        Position.End,
+        ReadFrom.End,
         1000,
         ReadDirection.Backward
       )
@@ -203,7 +203,7 @@ export function readStreamTestsFor(
     expect(
       await store.readStream(
         streamId,
-        Position.Start,
+        ReadFrom.Start,
         10,
         ReadDirection.Forward
       )
@@ -219,7 +219,7 @@ export function readStreamTestsFor(
     expect(
       await store.readStream(
         streamId,
-        Position.Start,
+        ReadFrom.Start,
         10,
         ReadDirection.Backward
       )
@@ -238,7 +238,7 @@ export function readStreamTestsFor(
     expect(
       await store.readStream(
         streamId,
-        Position.Start,
+        ReadFrom.Start,
         10,
         ReadDirection.Forward
       )
@@ -251,7 +251,7 @@ export function readStreamTestsFor(
       streamVersion: -1
     })
     expect(
-      await store.readStream(streamId, Position.End, 10, ReadDirection.Forward)
+      await store.readStream(streamId, ReadFrom.End, 10, ReadDirection.Forward)
     ).toEqual({
       isEnd: true,
       messages: [],
@@ -264,7 +264,7 @@ export function readStreamTestsFor(
     expect(
       await store.readStream(
         streamId,
-        Position.Start,
+        ReadFrom.Start,
         10,
         ReadDirection.Backward
       )
@@ -277,7 +277,7 @@ export function readStreamTestsFor(
       streamVersion: -1
     })
     expect(
-      await store.readStream(streamId, Position.End, 10, ReadDirection.Backward)
+      await store.readStream(streamId, ReadFrom.End, 10, ReadDirection.Backward)
     ).toEqual({
       isEnd: true,
       messages: [],

--- a/src/in-memory/in-memory-stream-store.ts
+++ b/src/in-memory/in-memory-stream-store.ts
@@ -14,7 +14,7 @@ import BigInteger from 'big-integer'
 import {
   NewStreamMessage,
   StreamVersion,
-  Position,
+  ReadFrom,
   MessagePosition,
   StreamMessage,
   OperationalStream,
@@ -138,7 +138,7 @@ export function createInMemoryStreamStore(
    */
   async function readStream(
     streamId: string,
-    fromVersionInclusive: StreamVersion | Position,
+    fromVersionInclusive: StreamVersion | ReadFrom,
     count: number,
     direction?: ReadDirection
   ): Promise<ReadStreamResult> {
@@ -152,7 +152,7 @@ export function createInMemoryStreamStore(
    */
   async function readStreamInternal(
     streamId: string,
-    fromVersionInclusive: StreamVersion | Position,
+    fromVersionInclusive: StreamVersion | ReadFrom,
     count: number,
     direction?: ReadDirection
   ): Promise<ReadStreamResult> {
@@ -169,9 +169,9 @@ export function createInMemoryStreamStore(
     }
 
     const startIndex =
-      fromVersionInclusive === Position.Start
+      fromVersionInclusive === ReadFrom.Start
         ? 0
-        : fromVersionInclusive === Position.End
+        : fromVersionInclusive === ReadFrom.End
         ? stream.messages.length - 1
         : stream.messages.findIndex(
             m => m.streamVersion >= fromVersionInclusive
@@ -277,16 +277,16 @@ export function createInMemoryStreamStore(
    * @param direction
    */
   async function readAll(
-    fromPositionInclusive: MessagePosition | Position,
+    fromPositionInclusive: MessagePosition | ReadFrom,
     count: number,
     direction?: ReadDirection
   ): Promise<ReadAllResult> {
     assertNotDisposed()
     invariant.validateReadAllRequest(fromPositionInclusive, count)
     const fromPos = BigInteger(fromPositionInclusive.toString())
-    const startIndex = fromPos.eq(Position.Start)
+    const startIndex = fromPos.eq(ReadFrom.Start)
       ? 0
-      : fromPos.eq(Position.End)
+      : fromPos.eq(ReadFrom.End)
       ? inMemoryAllStream.length - 1
       : inMemoryAllStream.findIndex(m => m.position.greaterOrEquals(fromPos))
 
@@ -390,7 +390,7 @@ export function createInMemoryStreamStore(
   ): Promise<StreamMetadataResult> {
     const read = await readStreamInternal(
       toMetadataStreamId(streamId),
-      Position.End,
+      ReadFrom.End,
       1,
       ReadDirection.Backward
     )

--- a/src/in-memory/in-memory-stream-store.ts
+++ b/src/in-memory/in-memory-stream-store.ts
@@ -537,8 +537,8 @@ export function createInMemoryStreamStore(
             resolve(subscription)
           },
           dispose: async () => {
-            subscriptions.splice(subscriptions.indexOf(subscription), 1)
             await callSubscriptionOptionsDisposer(subscriptionOptions)
+            subscriptions.splice(subscriptions.indexOf(subscription), 1)
             resolve(subscription)
           }
         }
@@ -572,8 +572,8 @@ export function createInMemoryStreamStore(
             resolve(subscription)
           },
           dispose: async () => {
-            subscriptions.splice(subscriptions.indexOf(subscription), 1)
             await callSubscriptionOptionsDisposer(subscriptionOptions)
+            subscriptions.splice(subscriptions.indexOf(subscription), 1)
             resolve(subscription)
           }
         }

--- a/src/postgres/pg-stream-store.ts
+++ b/src/postgres/pg-stream-store.ts
@@ -591,8 +591,8 @@ export function createPostgresStreamStore(
             resolve(subscription)
           },
           dispose: async () => {
-            subscriptions.splice(subscriptions.indexOf(subscription), 1)
             await callSubscriptionOptionsDisposer(subscriptionOptions)
+            subscriptions.splice(subscriptions.indexOf(subscription), 1)
             resolve(subscription)
           }
         }
@@ -624,8 +624,8 @@ export function createPostgresStreamStore(
             resolve(subscription)
           },
           dispose: async () => {
-            subscriptions.splice(subscriptions.indexOf(subscription), 1)
             await callSubscriptionOptionsDisposer(subscriptionOptions)
+            subscriptions.splice(subscriptions.indexOf(subscription), 1)
             resolve(subscription)
           }
         }

--- a/src/postgres/pg-stream-store.ts
+++ b/src/postgres/pg-stream-store.ts
@@ -17,7 +17,7 @@ import {
   NewStreamMessage,
   OperationalMessageType,
   OperationalStream,
-  Position,
+  ReadFrom,
   StreamMessage,
   StreamVersion
 } from '../types/messages'
@@ -231,14 +231,14 @@ export function createPostgresStreamStore(
    */
   async function readStream(
     streamId: string,
-    fromVersionInclusive: StreamVersion | Position,
+    fromVersionInclusive: StreamVersion | ReadFrom,
     count: number,
     direction = ReadDirection.Forward
   ): Promise<ReadStreamResult> {
     assertNotDisposed()
     invariant.validateReadStreamRequest(streamId, fromVersionInclusive, count)
     fromVersionInclusive =
-      fromVersionInclusive === Position.End
+      fromVersionInclusive === ReadFrom.End
         ? Number.MAX_SAFE_INTEGER
         : fromVersionInclusive
     const forward = direction === ReadDirection.Forward
@@ -324,12 +324,12 @@ export function createPostgresStreamStore(
    * @param count
    */
   async function readAllInternal(
-    fromPositionInclusive: MessagePosition | Position,
+    fromPositionInclusive: MessagePosition | ReadFrom,
     count: number,
     direction = ReadDirection.Forward
   ): Promise<ReadAllResult> {
     fromPositionInclusive =
-      fromPositionInclusive.toString() === Position.End.toString()
+      fromPositionInclusive.toString() === ReadFrom.End.toString()
         ? MAX_BIG_VALUE
         : fromPositionInclusive
     const forward = direction === ReadDirection.Forward
@@ -391,7 +391,7 @@ export function createPostgresStreamStore(
     invariant.validateReadStreamMetadataRequest(streamId)
     const result = await readStream(
       toMetadataStreamId(streamId),
-      Position.End,
+      ReadFrom.End,
       1,
       ReadDirection.Backward
     )

--- a/src/subscriptions/stream-subscription.ts
+++ b/src/subscriptions/stream-subscription.ts
@@ -42,6 +42,7 @@ export function createStreamSubscription(
   const loopLatch = createDuplexLatch()
   const disposeListener = notifier.listen(next.set)
   let _disposed = false
+  let _disposePromise: Promise<unknown> | null = null
   let _nextVersion = SubscribeAt.End
   const config: StreamSubscriptionOptions = {
     dispose: /* istanbul ignore next */ () => Promise.resolve(),
@@ -220,13 +221,16 @@ export function createStreamSubscription(
    * rather than the consumer disposing.
    */
   async function dispose() {
-    DisposedError.assert(!_disposed)
+    if (_disposePromise) {
+      await _disposePromise
+      return
+    }
     _disposed = true
     disposeListener()
     // In case we are waiting in the loop, make it continue so it can exit.
     next.set()
     // Waits for the loop to fully exit.
-    await loopLatch.wait()
-    await config.dispose!()
+    _disposePromise = loopLatch.wait().then(() => config.dispose!())
+    await _disposePromise
   }
 }

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -17,7 +17,7 @@ export type StreamVersion = number
 /**
  * Meta positions for reading.
  */
-export enum Position {
+export enum ReadFrom {
   /**
    * Read from the start of the stream.
    */

--- a/src/types/stream-store.ts
+++ b/src/types/stream-store.ts
@@ -3,7 +3,7 @@ import {
   NewStreamMessage,
   MessagePosition,
   StreamMessage,
-  Position
+  ReadFrom
 } from './messages'
 import {
   MessageProcessor,
@@ -40,7 +40,7 @@ export interface StreamStore {
    */
   readStream(
     streamId: string,
-    fromVersionInclusive: StreamVersion | Position,
+    fromVersionInclusive: StreamVersion | ReadFrom,
     count: number,
     direction?: ReadDirection
   ): Promise<ReadStreamResult>
@@ -53,7 +53,7 @@ export interface StreamStore {
    * @param direction
    */
   readAll(
-    fromPositionInclusive: MessagePosition | Position,
+    fromPositionInclusive: MessagePosition | ReadFrom,
     count: number,
     direction?: ReadDirection
   ): Promise<ReadAllResult>

--- a/src/utils/gap-detection.ts
+++ b/src/utils/gap-detection.ts
@@ -2,7 +2,7 @@ import BigInteger from 'big-integer'
 import { StreamStore, ReadDirection } from '../types/stream-store'
 import { Logger } from '../types/logger'
 import { delay } from './promise-util'
-import { Position } from '../types/messages'
+import { ReadFrom } from '../types/messages'
 
 /**
  * Detects gaps and reloads.
@@ -21,7 +21,7 @@ export async function detectGapsAndReloadAll(
   logger: Logger,
   reloadDelay: number,
   reloadTimes: number,
-  fromPositionInclusive: string | Position,
+  fromPositionInclusive: string | ReadFrom,
   count: number,
   readAll: StreamStore['readAll']
 ) {

--- a/src/utils/invariant.ts
+++ b/src/utils/invariant.ts
@@ -3,7 +3,7 @@ import validateUUID from 'uuid-validate'
 import {
   NewStreamMessage,
   MessagePosition,
-  Position,
+  ReadFrom,
   StreamVersion
 } from '../types/messages'
 import { ExpectedVersion, SetStreamMetadataOptions } from '..'
@@ -160,7 +160,7 @@ export function validateReadStreamRequest(
  * @param count
  */
 export function validateReadAllRequest(
-  fromPositionInclusive: MessagePosition | Position,
+  fromPositionInclusive: MessagePosition | ReadFrom,
   count: number
 ) {
   required('fromPositionInclusive', fromPositionInclusive)


### PR DESCRIPTION
**Better subscription disposal**

This fixes an issue where, if a subscription is disposed,
it would not be attached to the Store anymore, and so disposing
the Store wouldn't wait for the subscription to finish.

**Rename Position to ReadFrom**

This is a breaking change, but since Snicket is pre-1.0, I only want to
trigger a minor bump. Once I have shipped a production application
using Snicket, 1.0 will be released.